### PR TITLE
fix/layer: layer content overwritten by old content

### DIFF
--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -106,6 +106,7 @@ type layer = layerTemplate & {
   color: string;
   content: layerLine[];
   overwrite?: boolean;
+  layerId: string;
 };
 
 type autoSave = {

--- a/src/components/backup/Backup.tsx
+++ b/src/components/backup/Backup.tsx
@@ -6,6 +6,7 @@ import Popup from "@/components/popup/Popup";
 import { autoSave } from "@/@types/types";
 import Button from "@/components/button/Button";
 import { layerContext } from "@/components/LayerContext";
+import uuidUtil from "@/libraries/uuidUtil";
 
 type propType = {
   close: () => void;
@@ -35,6 +36,9 @@ const Backup: React.FC<propType> = (props) => {
       setLayerData(
         value.data.map((layer) => {
           layer.overwrite = true;
+          if (!layer.layerId) {
+            layer.layerId = uuidUtil.v4();
+          }
           return layer;
         })
       );

--- a/src/components/layer/Layer.tsx
+++ b/src/components/layer/Layer.tsx
@@ -48,12 +48,7 @@ const Layer = (props: LayerProps): JSX.Element => {
   };
   useEffect(() => {
     if (!layerElement.current || !optionData) return;
-    if (
-      !(
-        props.data.id === currentLayer.current?.id &&
-        props.data.pos === currentLayer.current?.pos
-      )
-    ) {
+    if (!(props.data.layerId === currentLayer.current?.layerId)) {
       props.data.overwrite = true;
     }
     currentLayer.current = props.data;

--- a/src/headers/Trace.tsx
+++ b/src/headers/Trace.tsx
@@ -23,6 +23,7 @@ import Options_ from "@/options/Options";
 import Popup from "@/components/popup/Popup";
 import localStorage from "@/libraries/localStorage";
 import Backup from "@/components/backup/Backup";
+import uuidUtil from "@/libraries/uuidUtil";
 
 /**
  * Traceブロック
@@ -144,6 +145,7 @@ const Trace = () => {
           content: layerUtil.generateLineFromTemplate(template),
           selected: true,
           color: "#000000",
+          layerId: uuidUtil.v4(),
         },
       ]);
     }, [layerData, layerDropdownValue]),
@@ -193,6 +195,9 @@ const Trace = () => {
         setLayerData(
           data.map((layer) => {
             layer.overwrite = true;
+            if (!layer.layerId) {
+              layer.layerId = uuidUtil.v4();
+            }
             return layer;
           })
         );

--- a/src/libraries/uuidUtil.ts
+++ b/src/libraries/uuidUtil.ts
@@ -1,0 +1,17 @@
+const v4 = () => {
+  // https://github.com/GoogleChrome/chrome-platform-analytics/blob/master/src/internal/identifier.js
+  // const FORMAT: string = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+  const chars = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".split("");
+  for (let i = 0, len = chars.length; i < len; i++) {
+    switch (chars[i]) {
+      case "x":
+        chars[i] = Math.floor(Math.random() * 16).toString(16);
+        break;
+      case "y":
+        chars[i] = (Math.floor(Math.random() * 4) + 8).toString(16);
+        break;
+    }
+  }
+  return chars.join("");
+};
+export default { v4 };


### PR DESCRIPTION
#96 
データが切り替わった際に新しい文字列がdomに残っていた古い文字列に上書きされてしまっていたので、新しいものが上書きされないように修正