### PR TITLE
fix/layer manager: run update when lost focus

### DIFF
--- a/src/libraries/layerManager.ts
+++ b/src/libraries/layerManager.ts
@@ -139,6 +139,7 @@ const layerManager = (
   };
   update();
   targetElement.oninput = update;
+  targetElement.onblur = update;
   targetElement.oncopy = (e) => {
     const copied = window.getSelection()?.toString() || "";
     e.clipboardData?.setData("text/plain", copied);


### PR DESCRIPTION
変換中にデータのみ更新しようとすると変更量が多くなってしまいそうだったので
フォーカスロスト時に更新を入れるようにしました
これでボタンを押す直前にデータの更新が入るので不整合は起きなくなると思います
-> https://github.com/eneko0513/NicoNicoDansaScriptCustom/issues/3#issuecomment-1221329462