### PR TITLE
fix: some chars are parsed as regex

### DIFF
--- a/src/libraries/layerUtil.ts
+++ b/src/libraries/layerUtil.ts
@@ -312,7 +312,7 @@ const getCharWidth = (char: string, font: commentFont): MonoChar => {
   }
   for (const regex in CharList) {
     const charItem = CharList[regex];
-    if (charItem && char.match(new RegExp(regex, "i"))) {
+    if (regex.length > 1 && charItem && char.match(new RegExp(regex, "i"))) {
       if (typeGuard.layer.isMonoChar(charItem)) return charItem;
       return { ...charItem, width: charItem.width[font] };
     }


### PR DESCRIPTION
「|」が正規表現と判定されてそれ以下の文字が全て「|」として処理されてしまっていたため修正