### PR TITLE
improve: keep current color when create new layer

### DIFF
--- a/src/headers/Trace.tsx
+++ b/src/headers/Trace.tsx
@@ -142,12 +142,19 @@ const Trace = () => {
       const id = layerUtil.getIdByValue(layerDropdownValue);
       const template = Templates[id];
       if (!typeGuard.trace.template(template)) return;
-      const _layerData = layerData.map((value) => {
-        value.selected = false;
-        return value;
-      });
+      const color: string | false | undefined = layerData.reduce((pv, val) => {
+        if (val.selected) {
+          val.selected = false;
+          if (pv === undefined) {
+            return val.color;
+          } else {
+            return false;
+          }
+        }
+        return pv;
+      }, undefined as undefined | false | string);
       setLayerData([
-        ..._layerData,
+        ...layerData,
         {
           ...template,
           type: id,
@@ -155,7 +162,7 @@ const Trace = () => {
           visible: true,
           content: layerUtil.generateLineFromTemplate(template),
           selected: true,
-          color: "#000000",
+          color: color || "#000000",
           layerId: uuidUtil.v4(),
         },
       ]);


### PR DESCRIPTION
まーさんの指摘
> 対象のレイヤーを選択して追加した際、カラーコードも引き継ぐようにしてほしい。（段スク時の仕様を引継いでほしい。）

に対応しました

レイヤー作成時、
1. 選択済みのレイヤーが有って
2. 選択済みのレイヤーが一つのみの場合

に選択済みのレイヤーの色を引き継ぎます