### PR TITLE
improve: add content length display on header of Output Tab

### DIFF
--- a/src/components/commentsDetail/CommentsDetail.module.scss
+++ b/src/components/commentsDetail/CommentsDetail.module.scss
@@ -1,0 +1,28 @@
+.wrapper {
+  min-width: 400px;
+  min-height: 200px;
+  max-height: 75vh;
+  overflow-y: scroll;
+}
+
+.table {
+  border: 1.5px solid black;
+
+  th,
+  td {
+    padding: 5px;
+    border: 1px solid black;
+    min-width: 55px;
+    text-align: right;
+  }
+
+  th {
+    text-align: center;
+  }
+
+  td.commandTd {
+    text-align: left;
+    max-width: 535px;
+    overflow-wrap: break-word;
+  }
+}

--- a/src/components/commentsDetail/CommentsDetail.tsx
+++ b/src/components/commentsDetail/CommentsDetail.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import Popup from "@/components/popup/Popup";
+import Styles from "./CommentsDetail.module.scss";
+
+type propType = {
+  textareaValue: string[];
+  isReverse: boolean;
+  close: () => void;
+};
+
+const CommentsDetail: React.FC<propType> = (props) => {
+  const getCommentDetail = (
+    text: string
+  ): { row: number; length: number; command: string } => {
+    const targetLine = text
+      ?.replace(/\[A0]/gi, "\u00A0")
+      .replace(/\[SP]/gi, "\u3000")
+      .replace(/\[00]/gi, "\u2000")
+      .replace(/\[01]/gi, "\u2001")
+      .replace(/\[02]/gi, "\u2002")
+      .replace(/\[03]/gi, "\u2003")
+      .replace(/\[04]/gi, "\u2004")
+      .replace(/\[05]/gi, "\u2005")
+      .replace(/\[06]/gi, "\u2006")
+      .replace(/\[0A]/gi, "\u200A")
+      .replace(/\[0B]/gi, "\u200B")
+      .replace(/\[TA?B]/gi, "\u0009");
+    let comment = targetLine;
+    let command = "";
+    for (;;) {
+      const match = comment?.match(/^(?:\[([^\]]+)])?(.*)/);
+      if (!match || !match[2]) break;
+      comment = match[2];
+      if (match[1]) {
+        const seekCommand = match[1].match(/tm(?:(\d+):)?(\d+)(?:\.(\d+))?/);
+        if (!seekCommand) {
+          command = match[1];
+        }
+      } else {
+        break;
+      }
+    }
+    comment = comment.replace(/<BR>/gi, "\n");
+    const row = comment.split("\n").length;
+    const length = comment.length;
+    return { row, length, command };
+  };
+  return (
+    <Popup
+      title={props.isReverse ? "コメント詳細(逆モード)" : "コメント詳細"}
+      close={props.close}
+    >
+      <div className={Styles.wrapper}>
+        {props.textareaValue.length == 0 ? (
+          <p>コメントがありません。</p>
+        ) : (
+          <table className={Styles.table}>
+            <thead>
+              <tr>
+                <th>コメ番</th>
+                <th>行数</th>
+                <th>文字数</th>
+                <th>コマンド</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.isReverse
+                ? props.textareaValue
+                    .map((v, i) => {
+                      const detail = getCommentDetail(v);
+                      return (
+                        <tr>
+                          <td>{i + 1}</td>
+                          <td>{detail.row}</td>
+                          <td>{detail.length}</td>
+                          <td className={Styles.commandTd}>{detail.command}</td>
+                        </tr>
+                      );
+                    })
+                    .reverse()
+                : props.textareaValue.map((v, i) => {
+                    const detail = getCommentDetail(v);
+                    return (
+                      <tr>
+                        <td>{i + 1}</td>
+                        <td>{detail.row}</td>
+                        <td>{detail.length}</td>
+                        <td className={Styles.commandTd}>{detail.command}</td>
+                      </tr>
+                    );
+                  })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </Popup>
+  );
+};
+
+export default CommentsDetail;


### PR DESCRIPTION
間違えてcommitしちゃった分も含めて

#132 `段スク時、コメント投稿する際Box欄にコメ数表示されていたのを復活して欲しい。`

f92866f702df324454d171daf70c87de2614e6ca improve: add content length display on header of Output Tab
    Optionタブのヘッダーの記載を`(進行度: 1/1 文字数: 75)`のような形式に変更

1e3e304ac11ba572c5af1adc2a2660cd97e525c7 fix: content length
    文字数計算時のcontentで`<br>`が変換されていなかったので処理を変更

ed3cb2f611221124f75d5879ae3d5a8f25794021 add: comments detail popup & fix: bugs
    コメント詳細タブの実装＆↑のバグを修正