### PR TITLE
[修正] 積みテンプレート関連の不具合を修正

### DIFF
--- a/src/libraries/layerUtil/main.ts
+++ b/src/libraries/layerUtil/main.ts
@@ -53,6 +53,16 @@ const layerComment2string = (
     }
     appendLine(output, layer, comment, line, options);
   }
+  if (output.length === 0) {
+    const isMultiCommentLayer =
+      layer.size.reduce((pv, val) => pv + (val.count ?? 0), 0) > 1;
+    if (isMultiCommentLayer) {
+      output.push({
+        content: ["\uA001"],
+        count: lines.length,
+      });
+    }
+  }
   return result2string(output, options);
 };
 


### PR DESCRIPTION
close #184  

- shita位置の積みテンプレート出力時に上下を反転する処理が抜けていたため修正
- 積みテンプレートに含まれる空コメントが消失する問題を修正

#180 で出力の内部処理をガッツリリファクタリングしたんですが、最近CAやってなさすぎて色々と考慮漏れしてました
申し訳ないです 🙇‍♂️ 