### PR TITLE
[実装] 投コメ編集画面に対応

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -21,10 +21,28 @@ div.grid-area_\[player\] > div[tabindex="0"] > div > div.p_base {
 section:has(div.grid-area_\[player\]) {
   grid-template-rows: min-content min-content min-content min-content min-content 1fr;
   grid-template-areas:
-    "d_header ."
+    "d_header d_header"
     "player sidebar"
     "d_footer sidebar"
     "meta sidebar"
     "bottom sidebar"
     ". sidebar";
+}
+
+div:has(div.grid-area_player) {
+  grid-template-rows: min-content min-content min-content min-content min-content 1fr;
+  grid-template-areas:
+    "header header"
+    "d_header d_header"
+    "player sidebar"
+    "d_footer sidebar"
+    "meta sidebar"
+    "bottom sidebar"
+    ". sidebar";
+}
+
+div:has(iframe[src^="https://www.nicovideo.jp/owner_comment_edit/"]){
+  width: 100vw;
+  height: 100vh;
+  max-height: unset;
 }

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -2,11 +2,7 @@ import { useAtom } from "jotai";
 
 import { useLocation } from "@/hooks/useLocation";
 import { elementAtom } from "@/libraries/atoms";
-import {
-  getElements,
-  getMainContainer,
-  getVideoElement,
-} from "@/libraries/getElements";
+import { getBaseElements, getElements } from "@/libraries/getElements";
 import { initVideoPlayer } from "@/libraries/videoPlayerApi";
 import "@/assets/global.scss";
 
@@ -35,7 +31,8 @@ export const Root = () => {
         check();
       });
       setElements(await getElements());
-      initVideoPlayer(getMainContainer(), getVideoElement());
+      const { mainContainer, videoElement } = await getBaseElements();
+      initVideoPlayer(mainContainer, videoElement);
     };
     void init();
   }, [location]);

--- a/src/entrypoints/content.tsx
+++ b/src/entrypoints/content.tsx
@@ -10,14 +10,17 @@ import {
   createMainElement,
   createMemoElement,
   getBaseElements,
-  getVideoContainer,
 } from "@/libraries/getElements";
 import { initVideoPlayer } from "@/libraries/videoPlayerApi";
 
 export default defineContentScript({
-  matches: ["https://www.nicovideo.jp/watch/*"],
+  matches: [
+    "https://www.nicovideo.jp/watch/*",
+    "https://www.nicovideo.jp/owner_comment_edit/*",
+  ],
   runAt: "document_start",
   world: "MAIN",
+  allFrames: true,
   main() {
     const init = async () => {
       const {
@@ -26,6 +29,7 @@ export default defineContentScript({
         videoContentContainer,
         videoCommentContainer,
         videoElement,
+        videoContainer,
       } = await getBaseElements();
       initVideoPlayer(mainContainer, videoElement);
       injectFetch();
@@ -38,7 +42,6 @@ export default defineContentScript({
           Storage.get("options_disable184") === "true" ? "#ff8300" : "#007cff";
       }
       */
-      const videoContainer = getVideoContainer();
       videoContainer.addEventListener(
         "scroll",
         (e) => {

--- a/src/libraries/getElements.ts
+++ b/src/libraries/getElements.ts
@@ -22,14 +22,15 @@ export const getElements = async (count = 0): Promise<TElement> => {
   ) {
     const videoContentContainer = getVideoContentContainer();
     BackgroundImageElement ??= createBackgroundImageElement();
-    videoContentContainer.appendChild(BackgroundImageElement);
+    videoContentContainer?.appendChild(BackgroundImageElement);
   }
   if (
     !(
       videoElement &&
       commentCommandInput &&
       commentCanvas &&
-      BackgroundImageElement
+      BackgroundImageElement &&
+      commentInputTextarea
     )
   ) {
     //1分超えたらfail
@@ -42,7 +43,7 @@ export const getElements = async (count = 0): Promise<TElement> => {
   if (!LayerElement || !document.body.contains(LayerElement)) {
     const videoCommentContiner = getVideoCommentContainer();
     LayerElement ??= createLayerElement();
-    videoCommentContiner.appendChild(LayerElement);
+    videoCommentContiner?.appendChild(LayerElement);
   }
   return {
     videoElement,
@@ -66,13 +67,17 @@ export const getBaseElements = async () => {
     const videoContentContainer = getVideoContentContainer();
     const videoCommentContainer = getVideoCommentContainer();
     const videoElement = getVideoElement();
+    const videoContainer = getVideoContainer();
     count++;
     if (
-      mainContainer === undefined ||
-      commentViewerContainer === undefined ||
-      videoContentContainer === undefined ||
-      videoCommentContainer === undefined ||
-      videoElement === undefined
+      !(
+        mainContainer &&
+        commentViewerContainer &&
+        videoContentContainer &&
+        videoCommentContainer &&
+        videoElement &&
+        videoContainer
+      )
     ) {
       await sleep(100);
       continue;
@@ -84,61 +89,59 @@ export const getBaseElements = async () => {
       videoContentContainer,
       videoCommentContainer,
       videoElement,
+      videoContainer,
     };
   }
   throw new Error("fail to get required element");
 };
 
-export const getMainContainer = () => {
-  return document.querySelectorAll(
-    "div.grid-area_\\[player\\]",
-  )[0] as HTMLDivElement;
+export const getMainContainer = (): HTMLDivElement | null => {
+  return (
+    document.querySelector("div.grid-area_\\[player\\]") ||
+    document.querySelector("div.grid-area_player")
+  );
 };
 
-export const getVideoElement = () => {
-  return document.querySelectorAll(
-    "div[data-name=content] > video",
-  )[0] as HTMLVideoElement;
+export const getVideoElement = (): HTMLVideoElement | null => {
+  return document.querySelector("div[data-name=content] > video");
 };
 
-export const getCommentViewerContainer = () => {
-  return document.querySelectorAll(
-    "div.grid-area_\\[sidebar\\] > div > div",
-  )[0] as HTMLDivElement;
+export const getCommentViewerContainer = (): HTMLElement | null => {
+  return (
+    document.querySelector(
+      "div.grid-area_\\[sidebar\\] > div > div > section", // コメント増量と衝突するのでsectionまで指定
+    )?.parentElement ||
+    document.querySelector("div.grid-area_sidebar > section")
+  );
 };
 
-export const getVideoContainer = () => {
-  return document.querySelectorAll("div[data-name=stage]")[0] as HTMLDivElement;
+export const getVideoContainer = (): HTMLDivElement | null => {
+  return document.querySelector("div[data-name=stage]");
 };
 
-export const getVideoContentContainer = () => {
-  return document.querySelectorAll(
-    "div[data-name=content]",
-  )[0] as HTMLDivElement;
+export const getVideoContentContainer = (): HTMLDivElement | null => {
+  return document.querySelector("div[data-name=content]");
 };
 
 export const getVideoCommentContainer = () => {
-  return document.querySelectorAll(
-    "div[data-name=comment]",
-  )[0] as HTMLDivElement;
+  return document.querySelector("div[data-name=comment]");
 };
 
-export const getCommentCommandInput = () => {
-  return document.querySelectorAll(
-    "input[placeholder='コマンド']",
-  )[0] as HTMLInputElement;
+export const getCommentCommandInput = (): HTMLInputElement | null => {
+  return document.querySelector(
+    "input[placeholder='コマンド'][tabindex='-1']", // 投コメ対応のためtabindexを指定
+  );
 };
 
-export const getCommentInputTextarea = () => {
-  return document.querySelectorAll(
-    "textarea[placeholder='コメントを入力']",
-  )[0] as HTMLTextAreaElement;
+export const getCommentInputTextarea = (): HTMLTextAreaElement | null => {
+  return (
+    document.querySelector("textarea[placeholder='コメントを入力']") ||
+    document.querySelector("textarea[placeholder='投稿者コメントを入力']")
+  );
 };
 
-export const getCommentCanvas = () => {
-  return document.querySelectorAll(
-    "div[data-name=comment] > canvas",
-  )[0] as HTMLCanvasElement;
+export const getCommentCanvas = (): HTMLCanvasElement | null => {
+  return document.querySelector("div[data-name=comment] > canvas");
 };
 
 export const getHeaderElement = () => {

--- a/src/libraries/getElements.ts
+++ b/src/libraries/getElements.ts
@@ -3,7 +3,7 @@ import type { TElement } from "@/types/element";
 
 /**
  * reactマウント用の親要素を取得する
- * @param count {number} リトライ回数
+ * @param count リトライ回数
  */
 export const getElements = async (count = 0): Promise<TElement> => {
   const videoElement = getVideoElement();

--- a/src/libraries/getElements.ts
+++ b/src/libraries/getElements.ts
@@ -41,9 +41,9 @@ export const getElements = async (count = 0): Promise<TElement> => {
     return await getElements(count + 1);
   }
   if (!LayerElement || !document.body.contains(LayerElement)) {
-    const videoCommentContiner = getVideoCommentContainer();
+    const videoCommentContainer = getVideoCommentContainer();
     LayerElement ??= createLayerElement();
-    videoCommentContiner?.appendChild(LayerElement);
+    videoCommentContainer?.appendChild(LayerElement);
   }
   return {
     videoElement,

--- a/src/libraries/getElements.ts
+++ b/src/libraries/getElements.ts
@@ -97,8 +97,8 @@ export const getBaseElements = async () => {
 
 export const getMainContainer = (): HTMLDivElement | null => {
   return (
-    document.querySelector("div.grid-area_\\[player\\]") ||
-    document.querySelector("div.grid-area_player")
+    document.querySelector("div.grid-area_\\[player\\]") || //通常画面
+    document.querySelector("div.grid-area_player") //投コメ編集画面
   );
 };
 
@@ -109,9 +109,10 @@ export const getVideoElement = (): HTMLVideoElement | null => {
 export const getCommentViewerContainer = (): HTMLElement | null => {
   return (
     document.querySelector(
+      // 通常画面
       "div.grid-area_\\[sidebar\\] > div > div > section", // コメント増量と衝突するのでsectionまで指定
     )?.parentElement ||
-    document.querySelector("div.grid-area_sidebar > section")
+    document.querySelector("div.grid-area_sidebar > section") // 投コメ編集画面
   );
 };
 
@@ -123,7 +124,7 @@ export const getVideoContentContainer = (): HTMLDivElement | null => {
   return document.querySelector("div[data-name=content]");
 };
 
-export const getVideoCommentContainer = () => {
+export const getVideoCommentContainer = (): HTMLDivElement | null => {
   return document.querySelector("div[data-name=comment]");
 };
 
@@ -135,8 +136,8 @@ export const getCommentCommandInput = (): HTMLInputElement | null => {
 
 export const getCommentInputTextarea = (): HTMLTextAreaElement | null => {
   return (
-    document.querySelector("textarea[placeholder='コメントを入力']") ||
-    document.querySelector("textarea[placeholder='投稿者コメントを入力']")
+    document.querySelector("textarea[placeholder='コメントを入力']") || // 通常画面
+    document.querySelector("textarea[placeholder='投稿者コメントを入力']") // 投コメ編集画面
   );
 };
 


### PR DESCRIPTION
- 投コメ編集画面に対応
- 通常画面でTraceが左に寄っていたので修正
- [コメント増量](https://github.com/tanbatu/comment-zouryou) と併用するとコメント増量側の画面内にMemo/Timeが吸い込まれていたため修正
- `querySelectorAll("...")[0]`を`querySelector("...")`で置き換え
# スクショ
- 通常画面
![image](https://github.com/user-attachments/assets/e5f3992a-c1e9-4829-b26f-2606a829c8f5)
- 投コメ編集画面
![image](https://github.com/user-attachments/assets/e33fc2eb-780f-4920-8856-89ad48db702f)
