### PR TITLE
[修正] 投コメ編集画面でレイヤーが選択できない不具合を修正

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -46,3 +46,7 @@ div:has(iframe[src^="https://www.nicovideo.jp/owner_comment_edit/"]){
   height: 100vh;
   max-height: unset;
 }
+
+div.pos_absolute.inset_0:has(div.pos_absolute.inset_0.d_flex.jc_center.ai_center.pointer-events_none.us_none){
+  pointer-events: none;
+}

--- a/src/components/footers/OutputBox.tsx
+++ b/src/components/footers/OutputBox.tsx
@@ -131,9 +131,13 @@ export const OutputBox = () => {
     const postAll = async () => {
       if (!elements) return;
       postAllCancel.current = false;
-      const isOwnerMode = !!location.href.match(
-        /^https:\/\/www\.nicovideo\.jp\/watch\/[^/]+\/edit\/owner_comment/,
-      );
+      const isOwnerMode =
+        !!location.href.match(
+          /^https:\/\/www\.nicovideo\.jp\/watch\/[^/]+\/edit\/owner_comment/,
+        ) ||
+        location.href.startsWith(
+          "https://www.nicovideo.jp/owner_comment_edit/",
+        );
       const length = textareaValue.length;
       const timeSpan = Number(
         Storage.get(


### PR DESCRIPTION
<img width="1753" alt="image" src="https://github.com/user-attachments/assets/8e57e606-e907-48c4-aed0-99c2b2697b3e" />

この要素、子要素に `pointer-events: none` が指定されているのに親要素に指定されていないせいで判定を吸っていたため、判定を無効化して対応

イベントも何も指定がないのに子要素だけ`pointer-events: none`がついているのは向こう側のミスな気もする...