### PR TITLE
修正: ニコニコ動画がRemixRouterからReactRouterへ移行したため変更に追従

### DIFF
--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 
 export const useLocation = () => {
   const [location, setLocation] = useState<RouterState["location"]>(
-    window.__remixRouter.state.location,
+    window.__reactRouterDataRouter.state.location,
   );
   useEffect(() => {
-    const unsubscribe = window.__remixRouter.subscribe((state) => {
+    const unsubscribe = window.__reactRouterDataRouter.subscribe((state) => {
       setLocation(state.location);
     });
     return () => {

--- a/src/types/declaration.d.ts
+++ b/src/types/declaration.d.ts
@@ -5,7 +5,7 @@ declare module "*.scss" {
 }
 interface Window {
   __videoplayer: NvPlayerApi;
-  __remixRouter: RemixRouter;
+  __reactRouterDataRouter: ReactRouter;
 }
 
 interface Event {
@@ -86,7 +86,7 @@ type PlayerOperation = {
   };
 };
 
-interface RemixRouter {
+interface ReactRouter {
   subscribe: (callback: (state: RouterState) => void) => () => void;
   state: RouterState;
 }


### PR DESCRIPTION
![{7EDF0FBE-397B-4453-BA72-2B36CF1E72C5}](https://github.com/user-attachments/assets/a342f2a2-13cc-4b9f-97ff-89cddb09d7a1)

![{0FA2D644-D81F-40CC-A1FC-209FD4F0D18D}](https://github.com/user-attachments/assets/8df48d6e-40e3-48d2-89e2-b20948120a21)

`window.__remixRouter`が消滅し、`window.__reactRouterDataRouter`が定義されている


![{6FF288EA-EFE9-485B-9661-9279D93BEAE4}](https://github.com/user-attachments/assets/c4facc94-41de-42cd-831c-252f2c583875)

![{D38D9930-24CA-4BF8-8927-1E0AB15FB22F}](https://github.com/user-attachments/assets/aa4883c4-6864-4eab-8236-94177eb0d79d)

メソッドやプロパティの内容には変化なさそうだったため、変数名のみ変更

